### PR TITLE
Lots of code cleanup -- removing unused variables

### DIFF
--- a/amplify.c
+++ b/amplify.c
@@ -23,9 +23,6 @@
 
 #define BUFSIZE 10000
 
-static gfloat amount_first[2] = {1.0,1.0} ;
-static gfloat amount_last[2] = {1.0,1.0} ;
-
 static gfloat amount_first_l[2] = {1.0,0.0} ;
 static gfloat amount_last_l[2] = {1.0,0.0} ;
 static gfloat amount_first_r[2] = {0.0,1.0} ;
@@ -171,7 +168,6 @@ int amplify_dialog(struct sound_prefs current, struct view *v)
     GtkWidget *amount_first_entry_r[2] ;
     GtkWidget *amount_last_entry_r[2] ;
     GtkWidget *feather_width_entry ;
-    int dclose = 0 ;
     int row = 0 ;
     int dres ;
     char buf[200] ;
@@ -259,7 +255,6 @@ int amplify_dialog(struct sound_prefs current, struct view *v)
 	    amount_last_r[i] = atof(gtk_entry_get_text((GtkEntry *)amount_last_entry_r[i])) ;
 	}
 	feather_width = atoi(gtk_entry_get_text((GtkEntry *)feather_width_entry)) ;
-	dclose = 1 ;
     }
 
 /*      {  */

--- a/audio_alsa.c
+++ b/audio_alsa.c
@@ -153,8 +153,6 @@ int audio_device_set_params(AUDIO_FORMAT *format, int *channels, int *rate)
         return -1;
     }
 
-    fprintf(stderr, "audio_device_handle %d\n",(int)handle);
-
     return 0;
 }
 
@@ -206,10 +204,10 @@ int audio_device_write(unsigned char *data, int count)
             snd_pcm_wait(handle, 1000);
         } else if (err < 0) {
 	    if(err == -EINVAL) {
-		fprintf(stderr, "snd_pcm_writei invalid argument: %d %d %d\n",(int)handle,(int)data,(int)count_frames);
+		fprintf(stderr, "snd_pcm_writei invalid argument: %p %d\n",(void *)data,(int)count_frames);
 		exit(1) ;
 	    } else if (recover_snd_handle(err) < 0) {
-		fprintf(stderr, "audio_device_write %d %d %d\n",(int)handle,(int)data,(int)count_frames);
+		fprintf(stderr, "audio_device_write %p %d\n",(void *)data,(int)count_frames);
                 snd_perr("ALSA audio_device_write: snd_pcm_writei", err);
 		exit(1) ;
                 return -1;

--- a/audio_device.h
+++ b/audio_device.h
@@ -45,6 +45,7 @@ int audio_device_read(unsigned char *buffer, int buffersize);
 int audio_device_write(unsigned char *buffer, int buffersize);
 void audio_device_close(int);
 long audio_device_processed_bytes(void);
+long audio_device_processed_frames(void);
 int audio_device_best_buffer_size(int playback_bytes_per_block);
 int audio_device_nonblocking_write_buffer_size(int maxbufsize,
                                                int playback_bytes_remaining);

--- a/audio_osx.c
+++ b/audio_osx.c
@@ -163,9 +163,7 @@ macosx_audio_out_callback (AudioDeviceID device, const AudioTimeStamp* current_t
 	return noErr;
 } 
 
-int process_audio(gfloat *pL, gfloat *pR)  //This function must be called repeatedly from the gint play_a_block until the section is played. 
-{	//The pointers pL and pR passed in above return the levels for the VU meters.
-	fprintf(stderr, "Process Audio for OS X is now broken, need to fix it for led_level_\n") ;
+int process_audio(gfloat *pL, gfloat *pR)
 	if(audio_state == AUDIO_IS_IDLE) 
 	{
 		d_print("process_audio says AUDIO_IS_IDLE is going on.\n") ;
@@ -279,7 +277,8 @@ int audio_device_set_params(AUDIO_FORMAT *format, int *channels, int *rate) //An
 
 int audio_device_read(unsigned char *buffer, int buffersize){return 0;} // Leave this stub function because we don't want to read data.
 int audio_device_write(unsigned char *buffer, int buffersize){return 0;} // Not quite what the title says in OS X.
-long audio_device_processed_bytes(void)
+
+long audio_device_processed_frames(void)
 {
 	AudioTimeStamp this_time;
 	OSStatus err;
@@ -302,7 +301,8 @@ long audio_device_processed_bytes(void)
 		}
 		else
 		{
-			playback_read_frame_position = (long) (this_time.mSampleTime - start_sample_time);//*FRAMESIZE;
+			// it appears that mSampleTime really is the sampel frame number, it is not a time.   Just a poorly named variable in coreaudio
+			playback_read_frame_position = (long) (this_time.mSampleTime - start_sample_time);
 		}
 	}
 	if (playback_read_frame_position >= playback_end_frame)  //We are done playing.
@@ -312,7 +312,14 @@ long audio_device_processed_bytes(void)
 		audio_playback = FALSE;
 	}
 	
-	return playback_read_frame_position*FRAMESIZE
+	printf("DEBUG:============ OSX says current Frame # is %ld\n", playback_read_frame_position) ;
+	return playback_read_frame_position ;
+		;
+}  // This is used to set the cursor.  We need to make this return a number controlled by a timer.
+
+long audio_device_processed_bytes(void)
+{
+    return audio_device_processed_frames()*FRAMESIZE ;
 		;
 }  // This is used to set the cursor.  We need to make this return a number controlled by a timer.
 

--- a/audio_osx.c
+++ b/audio_osx.c
@@ -127,8 +127,8 @@ macosx_audio_out_callback (AudioDeviceID device, const AudioTimeStamp* current_t
 			extern int audio_is_looping ;
 			extern gint totblocks_in_led_levels ;
 			extern int buffered_looped_count ;
-			extern gfoat *led_levels_l ;
-			extern gfoat *led_levels_r ;
+			extern gfloat *led_levels_l ;
+			extern gfloat *led_levels_r ;
 			extern gint LED_LEVEL_FRAME_SIZE ;
 
 			if(audio_is_looping == FALSE || buffered_looped_count == 0) {
@@ -303,8 +303,6 @@ long audio_device_processed_bytes(void)
 		else
 		{
 			playback_read_frame_position = (long) (this_time.mSampleTime - start_sample_time);//*FRAMESIZE;
-																				   //led_bar_light_percent(dial[0], l);  
-																				   //led_bar_light_percent(dial[1], r);
 		}
 	}
 	if (playback_read_frame_position >= playback_end_frame)  //We are done playing.

--- a/audio_util.c
+++ b/audio_util.c
@@ -348,14 +348,6 @@ gint n_frames_in_led_levels ;  // number of frames of data loaded into the led_l
 gint totblocks_in_led_levels ; // number of blocks (elements) alloc()'ed in the led_levels_r and led_levels_l arrays
 gint LED_LEVEL_FRAME_SIZE = 4410 ;  // number of frames examined for max values in a single led_level element, will be reset based on prefs.rate
 
-			extern gint n_frames_in_led_levels ;
-			extern int audio_is_looping ;
-			extern gint totblocks_in_led_levels ;
-			extern int buffered_looped_count ;
-			extern gfoat *led_levels_l ;
-			extern gfoat *led_levels_r ;
-			extern gint LED_LEVEL_FRAME_SIZE ;
-
 void get_led_levels(gfloat *pL, gfloat *pR, gfloat *pLold, gfloat *pRold, long frame_number)
 {
     int block = frame_number/LED_LEVEL_FRAME_SIZE ;

--- a/audio_util.c
+++ b/audio_util.c
@@ -296,7 +296,7 @@ long set_playback_cursor_position(struct view *v, long millisec_per_visual_frame
 {
     if((audio_state&AUDIO_IS_PLAYING)) {
 	// determine number of frames played thru the audio device (may have some error in it, but should be very close)
-	long device_frames_played = audio_device_processed_bytes()/PLAYBACK_FRAMESIZE - looped_count*playback_total_frames ;
+	long device_frames_played = audio_device_processed_frames() - looped_count*playback_total_frames ;
 	long delta_dfp = device_frames_played-prev_device_frames_played ;
 
 	if(!(audio_state&AUDIO_IS_BUFFERING)) {
@@ -895,7 +895,7 @@ struct sound_prefs open_wavefile(char *filename, struct view *v)
 #endif
 
     FRAMESIZE = BYTESPERSAMPLE*wfh.n_channels ;
-    PLAYBACK_FRAMESIZE = 2*wfh.n_channels ;
+    PLAYBACK_FRAMESIZE = BYTESPERSAMPLE*wfh.n_channels ;
 
     wfh.playback_bits = audio_bits = wfh.bits = BYTESPERSAMPLE*8 ;
 

--- a/biquad.c
+++ b/biquad.c
@@ -118,10 +118,8 @@ void filter_audio(struct sound_prefs *p, long first, long last, int channel_mask
     long left[BUFSIZE], right[BUFSIZE] ;
     long x_left[3], x_right[3] ;
     long y_left[3], y_right[3] ;
-    long current, i, f ;
+    long current, i ;
     int loops = 0 ;
-    long ring_buffer_length ;
-    double rb_left[BUFSIZE], rb_right[BUFSIZE] ;
 
     load_filter_preferences() ;
 
@@ -145,11 +143,6 @@ void filter_audio(struct sound_prefs *p, long first, long last, int channel_mask
     g_print(" Fc:%lg bandwidth:%lg srate:%d\n", Fc, bandwidth,p->rate) ;
 
 
-/*  filtered_sample = current_sample - ring_buffer[j];  */
-/*  ring_buffer[j] = ring_buffer[j] * 0.9 + current_sample * 0.1;  */
-/*  j++;  */
-/*  j %= ring_buffer_length;  */
-
 #define MAXH 5
 #ifdef BIQUAD_CALL
 extern biquad *BiQuad_new(int type, smp_type dbGain, /* gain of filter */
@@ -164,11 +157,6 @@ extern biquad *BiQuad_new(int type, smp_type dbGain, /* gain of filter */
     iir_left  = BiQuad_new(filter_type, dbGain, Fc, p->rate, bandwidth) ;
     iir_right = BiQuad_new(filter_type, dbGain, Fc, p->rate, bandwidth) ;
 
-    ring_buffer_length = p->rate / Fc + 0.5 ;
-    for(i = 0 ; i < ring_buffer_length ; i++) {
-	rb_left[i] = 0.0 ;
-	rb_right[i] = 0.0 ;
-    }
 #else
     FILTER iir_left, iir_right ;
 
@@ -340,7 +328,6 @@ int filter_dialog(struct sound_prefs current, struct view *v)
 {
     GtkWidget *dlg, *dialog_table ;
     GtkWidget *feather_entry ;
-    int dclose = 0 ;
     int row = 0 ;
     int dres ;
 
@@ -421,7 +408,6 @@ int filter_dialog(struct sound_prefs current, struct view *v)
 	filter_prefs.Fc = Fc ;
 	filter_prefs.bandwidth = bandwidth ;
 	filter_prefs.filter_type = filter_type ;
-	dclose = 1 ;
     }
 
     gtk_widget_destroy(dlg) ;

--- a/declick.c
+++ b/declick.c
@@ -249,7 +249,7 @@ int lsar_sample_restore(fftw_real data[], int firstbad, int lastbad, int siglen)
 #ifdef MESCHACH
     int n_bad = lastbad - firstbad + 1 ;
     int autolen = 60 ;
-    int i, j, rows, cols ;
+    int i, j, rows ;
     int rcode ;
     gboolean clipped ;
     double x[100], auto_coefs[101] ;
@@ -300,7 +300,6 @@ int lsar_sample_restore(fftw_real data[], int firstbad, int lastbad, int siglen)
 	for(i = firstbad ; i <= lastbad ; i++) sig->ve[i] = 0.0 ;
 
 	rows = siglen - autolen ;
-	cols = siglen ;
 
 	for(i = 0 ; i < rows ; i++) {
 
@@ -743,7 +742,6 @@ struct click_data *clicks, int iterate_flag, int leave_click_marks)
     }
 
     for(window_first = first_sample ; !done && window_first < last_sample ; window_first += window_step ) {
-	int clicks_repaired = 1 ;
 	int min_sample,max_sample ;
 
 	if(window_first + window_size > last_sample) {
@@ -915,7 +913,6 @@ struct click_data *clicks, int iterate_flag, int leave_click_marks)
 			} else {
 			    n_repaired[channel]++ ;
 			    n_this_pass ++ ;
-			    clicks_repaired = 1 ;
 			}
 		    }
 		    in_click = 0 ;
@@ -1072,12 +1069,9 @@ struct click_data *clicks, int iterate_flag, int leave_click_marks)
 				click_end = window_first + i ;
 			    }
 			} else if(in_click == 1 && !sample_is_in_click) {
-			    long width ;
 			    int result = DETECT_ONLY ;
 			    click_start = window_first+i ;
-			    width = click_end - click_start ;
-    /*  			click_start -= width ;  */
-    /*  			click_end += width ;  */
+
 			    if(click_start < 0) click_start = 0 ;
 			    if(click_end > p->n_samples) click_end = p->n_samples ;
 

--- a/dethunk.c
+++ b/dethunk.c
@@ -79,7 +79,6 @@ int dethunk_new(struct sound_prefs *pPrefs,
 #else /* HAVE_FFTW3 */
     rfftw_plan pFor,pBak ;
 #endif /* HAVE_FFTW3 */
-    double dfs, hdfs ;
     extern struct view audio_view ;
     int FFT_SIZE ;
     int repair_size ;
@@ -90,9 +89,6 @@ int dethunk_new(struct sound_prefs *pPrefs,
 
     repair_size = FFT_SIZE * n_want ;
     n_windows = 2*n_want - 1 ;
-
-    dfs = FFT_SIZE ;
-    hdfs = FFT_SIZE / 2 ;
 
     {
 	long extra_samples = repair_size - n_samples ;
@@ -110,6 +106,9 @@ int dethunk_new(struct sound_prefs *pPrefs,
     cancel = save_undo_data( first_sample, last_sample, pPrefs, TRUE) ;
     close_undo() ;
     pop_status_text() ;
+
+    if(cancel == 1)
+	return 0 ;
 
     n_samples = last_sample - first_sample + 1 ;
 
@@ -345,7 +344,7 @@ int dethunk_current(struct sound_prefs *pPrefs,
 #else /* HAVE_FFTW3 */
     rfftw_plan pFor ;
 #endif /* HAVE_FFTW3 */
-    double dfs, hdfs ;
+    double hdfs ;
     extern struct view audio_view ;
     int FFT_SIZE ;
 
@@ -353,7 +352,6 @@ int dethunk_current(struct sound_prefs *pPrefs,
 
     for(FFT_SIZE = 8 ; FFT_SIZE < n_samples && FFT_SIZE < 8192 ; FFT_SIZE *= 2) ;
 
-    dfs = FFT_SIZE ;
     hdfs = FFT_SIZE / 2 ;
 
     {
@@ -372,6 +370,9 @@ int dethunk_current(struct sound_prefs *pPrefs,
     cancel = save_undo_data( first_sample, last_sample, pPrefs, TRUE) ;
     close_undo() ;
     pop_status_text() ;
+
+    if(cancel == 1)
+	return 0 ;
 
     n_samples = last_sample - first_sample + 1 ;
 
@@ -642,6 +643,9 @@ int dethunk(struct sound_prefs *pPrefs,
     cancel = save_undo_data( first_sample, last_sample, pPrefs, TRUE) ;
     close_undo() ;
     pop_status_text() ;
+
+    if(cancel == 1)
+	return 0 ;
 
     n_samples = last_sample - first_sample + 1 ;
 

--- a/drawing.c
+++ b/drawing.c
@@ -313,14 +313,15 @@ int _audio_area_button_event(GtkWidget *c, GdkEventButton *event)
 	long select_last = audio_view.last_sample ;
 
 	int i ;
-	for(i = 0 ; i < num_song_markers ; i++) {
-	    if(song_markers[i] < 0) continue ;
 
-	    if(song_markers[i] > click_sample && song_markers[i] < select_last)
-		select_last = song_markers[i] ;
+	for(i = 0 ; i < n_markers ; i++) {
+	    if(markers[i] < 0) continue ;
 
-	    if(song_markers[i] < click_sample && song_markers[i] > select_first)
-		select_first = song_markers[i] ;
+	    if(markers[i] > click_sample && markers[i] < select_last)
+		select_last = markers[i] ;
+
+	    if(markers[i] < click_sample && markers[i] > select_first)
+		select_first = markers[i] ;
 	}
 
 
@@ -491,12 +492,10 @@ void draw_sonogram(struct view *v, struct sound_prefs *pPrefs, GtkWidget *da, do
     int y ;
     int spec_start, spec_stop;
     int channel;
-    double spectrum_scale;
     int index_20Hz;
 
 #define MAXSW 2000
 #define MAXSH 400
-    unsigned char level[2][MAXSW][MAXSH] ;
 
     push_status_text("Building sonogram") ;
     update_progress_bar(0.0,PROGRESS_UPDATE_INTERVAL,TRUE) ;
@@ -529,7 +528,6 @@ void draw_sonogram(struct view *v, struct sound_prefs *pPrefs, GtkWidget *da, do
 
        /* Normalize energy based on number of bins relative to maximum
           length FFT */
-    spectrum_scale = spectral_amp * sqrt((double) FFT_SIZE / FFT_MAX) * 4.0;
 #ifdef HAVE_FFTW3
     pLeft = FFTW(plan_r2r_1d)(FFT_SIZE, left, out, FFTW_R2HC, FFTW_ESTIMATE);
     pRight = FFTW(plan_r2r_1d)(FFT_SIZE, right, out, FFTW_R2HC, FFTW_ESTIMATE);
@@ -574,8 +572,6 @@ ly2_tbl[0] = 99999999;
     ly_offset[1] = AtoS(-(1-m-1),FFT_SIZE/4.0,1,v->canvas_height) - ly1_tbl[1];
 
     for(x = 0 ; x < v->canvas_width ; x++) {
-	long mid_sample ;
-
         update_progress_bar((double) x / v->canvas_width,PROGRESS_UPDATE_INTERVAL,FALSE) ;
 
 	sample = pixel_to_sample(&audio_view, x) ;
@@ -587,7 +583,6 @@ ly2_tbl[0] = 99999999;
 	if(max_sample > audio_view.n_samples-1)
 	    max_sample = audio_view.n_samples-1 ;
 
-	mid_sample = (max_sample-min_sample+1)/2 ;
 	read_fft_real_wavefile_data(left,  right, min_sample, max_sample) ;
 
 	for(k = 0 ; k < FFT_SIZE ; k++) {
@@ -686,10 +681,12 @@ ly2_tbl[0] = 99999999;
 
 	    for(k = 1 ; k <= FFT_SIZE/2 ; k++) {
 		int y ;
+
 		color = psk_to_color(power_spectrum[k]*spectral_amp, 1.0, 255) ;
+
 		if(color < 0) color=0 ; 
-		level[channel][x][k-1] = color ;
 		if(color > 255) color=255 ;
+
 		{ 
 		    for(y = ly2_tbl[k] ; y < ly1_tbl[k] ; y++) {
 			gdk_image_put_pixel(image, x, y + ly_offset[channel], sonogram_color[color].pixel);
@@ -1204,7 +1201,6 @@ void redraw(struct view *v, struct sound_prefs *p, GtkWidget *da, int cursor_fla
 	    double last_right_rmse = -1.0 ;
 	    double left_rmse = -1 ;
 	    double right_rmse = -1 ;
-	    double samp_width = 1./samples_per_pixel ;
 
 	    for(x = 0 ; x < v->canvas_width ; x++) {
 		int s_at_x = (double)x / (double)(v->canvas_width-1) * n_view_samples + v->first_sample ;

--- a/gtkled.c
+++ b/gtkled.c
@@ -90,10 +90,6 @@ gtk_led_class_init (GtkLedClass *class)
 void
 gtk_led_init (GtkLed *led)
 {
-  GtkMisc *misc;
-  
-  misc = GTK_MISC (led);
-
   GTK_WIDGET_SET_FLAGS (led, GTK_NO_WINDOW);
   
   led->is_on             = FALSE;
@@ -157,12 +153,8 @@ gtk_led_is_on (GtkLed  *led)
 static void
 gtk_led_destroy (GtkObject *object)
 {
-  GtkLed *led;
-  
   g_return_if_fail (object != NULL);
   g_return_if_fail (GTK_IS_LED (object));
-  
-  led = GTK_LED (object);
   
   if (GTK_WIDGET (object)->parent &&
       GTK_WIDGET_MAPPED (object))

--- a/gtkledbar.c
+++ b/gtkledbar.c
@@ -53,10 +53,9 @@ led_bar_get_type ()
 static void
 led_bar_class_init (LedBarClass *class)
 {
-  GtkObjectClass   *object_class;
-
-  object_class = (GtkObjectClass *) class;
-
+  // apparently nothing happens in the init function anymore?  JJW Jan 25, 2021
+  //GtkObjectClass   *object_class;
+  //object_class = (GtkObjectClass *) class;
 }
 
 static void

--- a/gwc.c
+++ b/gwc.c
@@ -1183,8 +1183,6 @@ void gnome_flush(void)
 
 gint playback_timer_function(gpointer data)
 {
-    long cursor_samples_per_pixel;
-    long cursor_millisec;
     gfloat l, r;
     gfloat l10, r10; // max led level in past 10 blocks
     long last, first;
@@ -1234,7 +1232,6 @@ gint playback_timer_function(gpointer data)
 * in this example. More on callbacks below. */
 void start_gwc_playback(GtkWidget * widget, gpointer data)
 {				/* Play audio */
-    long millisec_per_block;
     int device_framesize ;
 
     audio_debug_print("entering start_gwc_playback with audio_playback=%d\n", audio_playback) ;

--- a/gwc.h
+++ b/gwc.h
@@ -55,6 +55,10 @@
 #define PROGRESS_UPDATE_INTERVAL 0.5	/* update status bar every 1/2  second on long edit operations */
 #define MAX_AUDIO_BUFSIZE 32768
 
+// a couple of macros to handle read(), and write() calls to track number of bytes input(output) 
+#define LL_READ(fd,p,n,n_tot,n_read) { n_tot += (n) ; n_read += read(fd,(p),n) ; }
+#define LL_WRITE(fd,p,n,n_tot,n_wrote) { n_tot += (n) ; n_wrote += write(fd,(p),n) ; }
+
 /* defs for declicking results */
 #define SINGULAR_MATRIX 0
 #define REPAIR_SUCCESS 1

--- a/markers.c
+++ b/markers.c
@@ -308,10 +308,6 @@ void cdrdao_toc_info(char *filename)
 void store_cdrdao_toc(gpointer user_data)
 {
     if(strcmp(save_cdrdao_toc_filename, wave_filename)) {
-	int l ;
-
-	l = strlen(save_cdrdao_toc_filename) ;
-
 	d_print("Save cdrdao_toc to %s\n", save_cdrdao_toc_filename) ;
 
 	cdrdao_toc_info(save_cdrdao_toc_filename) ;

--- a/pinknoise.c
+++ b/pinknoise.c
@@ -253,7 +253,6 @@ int pinknoise_dialog(struct sound_prefs current, struct view *v)
     GtkWidget *amount_pink_entry ;
     GtkWidget *amount_white_entry ;
     GtkWidget *feather_width_entry ;
-    int dclose = 0 ;
     int row = 0 ;
     int dres ;
 
@@ -283,7 +282,6 @@ int pinknoise_dialog(struct sound_prefs current, struct view *v)
 	amount_white = atof(gtk_entry_get_text((GtkEntry *)amount_white_entry)) ;
 	feather_width = atoi(gtk_entry_get_text((GtkEntry *)feather_width_entry)) ;
 	n_pn_rows = atoi(gtk_entry_get_text((GtkEntry *)n_rows_entry)) ;
-	dclose = 1 ;
     }
 
     gtk_widget_destroy(dlg) ;

--- a/reverb.c
+++ b/reverb.c
@@ -151,7 +151,7 @@ void reverb_selection_made( GtkWidget      *clist,
 
 int reverb_dialog(struct sound_prefs current, struct view *v)
 {
-    GtkWidget *dlg, *maxtext, *dialog_table, *settings_frame ;
+    GtkWidget *dlg, *dialog_table ;
     GtkWidget *wet_entry ;
     GtkWidget *dry_entry ;
     GtkWidget *decay_entry ;
@@ -160,11 +160,8 @@ int reverb_dialog(struct sound_prefs current, struct view *v)
 
     gchar *reverb_method_window_titles[] = { "TAP Reverb Name" };
 
-    int dclose = 0 ;
     int row = 0 ;
     int dres ;
-    char buf[200] ;
-
 
     dialog_table = gtk_table_new(5,2,0) ;
 
@@ -235,12 +232,10 @@ int reverb_dialog(struct sound_prefs current, struct view *v)
     dres = gwc_dialog_run(GTK_DIALOG(dlg)) ;
 
     if(dres == 0) {
-	int i ;
 	wet_level = atoi(gtk_entry_get_text((GtkEntry *)wet_entry)) ;
 	dry_level = atoi(gtk_entry_get_text((GtkEntry *)dry_entry)) ;
 	decay = atoi(gtk_entry_get_text((GtkEntry *)decay_entry)) ;
 	save_reverb_preferences() ;
-	dclose = 1 ;
     }
 
     gtk_widget_destroy(dlg) ;

--- a/stat.c
+++ b/stat.c
@@ -18,7 +18,7 @@ void matrix_solve(MAT *) ;
 static MAT *coef = MNULL ;
 static VEC *b = VNULL ;
 static VEC *answer = VNULL ;
-static int row, col, N, i ;
+static int row, col, N ;
 static int failed ;
 
 /* LUsolve -- given an LU factorisation in A, solve Ax=b */


### PR DESCRIPTION
Attempt to code led level meters appropriately in audio_osx.c

Alister -- I anticipate at a minimum there will be leftover unused variables in audio_osx.c   Likely some typos as well.

While all I did, theoretically is remove unused variables, and clean up warnings in all the code, this is really in need of serious testing to make sure I didn't create new bugs.  It compiles cleanly (save 1 warning about ignoring the result of a system call in gwc.c)   I made a new branch so we can test it before merging back into master.